### PR TITLE
Fix ARIA attribute typo in Message component

### DIFF
--- a/src/components/ui/message.tsx
+++ b/src/components/ui/message.tsx
@@ -37,7 +37,6 @@ const MessageFunctions = forwardRef<HTMLDivElement, MessageControlsProps>(({
       aria-label="Message actions"
       role="toolbar"
       aria-orientation="horizontal"
-      aria-orientation-sm="vertical" 
       tabIndex={0}
     >
       <Button


### PR DESCRIPTION
## Summary
- remove an invalid `aria-orientation-sm` attribute from `MessageFunctions`

## Testing
- `bash -c "source start_env && ./run_tests.sh"` *(fails: vitest not found)*