### PR TITLE
Update web scraper results schema

### DIFF
--- a/agents/chloe/src/tests/test_web_scraper.py
+++ b/agents/chloe/src/tests/test_web_scraper.py
@@ -35,6 +35,7 @@ def test_successful_scrape(mock_get):
     assert "error" not in result
     assert result["title"] == "Test Page"
     assert result["url"] == "https://example.com"
+    assert result["metadata"] == {"displayType": "web-scraper"}
     
     # Check content is present
     assert "This is test content." in result["text"]
@@ -57,7 +58,8 @@ def test_selector_extraction(mock_get, monkeypatch):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
     
-    result = web_scraper("http://fake.com", selectors={"content": ".foo"})
+    result = web_scraper("http://fake.com", selector=".foo")
     
     assert "bar" in result["text"]
     assert result["url"] == "http://fake.com"
+    assert result["metadata"] == {"displayType": "web-scraper"}

--- a/agents/chloe/src/tests/test_web_scraper_tool.py
+++ b/agents/chloe/src/tests/test_web_scraper_tool.py
@@ -46,6 +46,7 @@ class TestWebScraperTool(unittest.TestCase):
         self.assertNotIn("error", result)
         self.assertEqual(result["title"], "Test Title")
         self.assertEqual(result["url"], "https://test.com")
+        self.assertEqual(result["metadata"], {"displayType": "web-scraper"})
         
         # Check that content is present
         self.assertIn("First paragraph.", result["text"])
@@ -82,12 +83,13 @@ class TestWebScraperTool(unittest.TestCase):
         mock_response.raise_for_status.return_value = None
         mock_get.return_value = mock_response
 
-        result = web_scraper("https://test.com", selectors={"content": ".content"})
+        result = web_scraper("https://test.com", selector=".content")
         self.assertNotIn("error", result)
         self.assertEqual(result["title"], "Test Title")
         self.assertEqual(result["url"], "https://test.com")
         self.assertIn("Target content", result["text"])
         self.assertNotIn("Ignore this", result["text"])
+        self.assertEqual(result["metadata"], {"displayType": "web-scraper"})
 
     @patch('requests.get')
     def test_web_scraper_http_error(self, mock_get):


### PR DESCRIPTION
## Summary
- adjust web_scraper tool to return `text` instead of `content`
- include page titles and display metadata
- update web scraper tests for new result structure

## Testing
- `./run_tests.sh` *(fails: vitest not found)*